### PR TITLE
Adds Int.secondsToHHmm: Pair<Int, Int>

### DIFF
--- a/library/src/main/java/tmg/utilities/extensions/IntExtensions.kt
+++ b/library/src/main/java/tmg/utilities/extensions/IntExtensions.kt
@@ -3,6 +3,7 @@ package tmg.utilities.extensions
 import android.content.Context
 import android.content.res.Resources
 import tmg.utilities.utils.DensityUtils
+import kotlin.math.floor
 
 //region Density conversions
 
@@ -107,6 +108,21 @@ fun Int.secondsToHHmm(): String? {
     val minutes: String = ((this / 60) % 60).extend(2)
     return "$hours:$minutes"
 }
+
+
+
+/**
+ * Given that the number is in seconds, convert it to a pair containing hours and minutes
+ */
+val Int.secondsToHHmm: Pair<Int, Int>
+    get() {
+        if (this < 0) {
+            return Pair(0, 0)
+        }
+        val hours = floor(this / 3600f).toInt()
+        val minutes = floor((this % 3600f) / 60f).toInt()
+        return Pair(hours, minutes)
+    }
 
 //endregion
 

--- a/library/src/test/java/tmg/utilities/extensions/IntExtensionsKtTest.kt
+++ b/library/src/test/java/tmg/utilities/extensions/IntExtensionsKtTest.kt
@@ -45,6 +45,20 @@ class IntExtensionsKtTest {
 
     @ParameterizedTest
     @CsvSource(
+        "86400,24,0",
+        "88200,24,30",
+        "86399,23,59",
+        "43200,12,00",
+        "0,0,0",
+        "-1,0,0"
+    )
+    fun `IntExtensions secondsToHHmm formats a valid time`(seconds: Int, expectedHours: Int, expectedMinutes: Int) {
+        assertEquals(expectedHours, seconds.secondsToHHmm.first)
+        assertEquals(expectedMinutes, seconds.secondsToHHmm.second)
+    }
+
+    @ParameterizedTest
+    @CsvSource(
         "3,0,4,0003",
         "0,1,2,10",
         "-1,2,4,-1",


### PR DESCRIPTION
Adds the extension `Int.secondsToHHmm: Pair<Int, Int>` extension, which splits a seconds value into hours and minutes