### PR TITLE
Changes SharedPrefManager.prefsKey to open instead of abstract

### DIFF
--- a/library/src/main/java/tmg/utilities/prefs/SharedPrefManager.kt
+++ b/library/src/main/java/tmg/utilities/prefs/SharedPrefManager.kt
@@ -23,7 +23,7 @@ abstract class SharedPrefManager(
         replaceWith = ReplaceWith("prefConfig"),
         level = DeprecationLevel.ERROR
     )
-    abstract val prefsKey: String?
+    open val prefsKey: String? = null
 
     /**
      * Specify the preference mode


### PR DESCRIPTION
Allow it to be deleted in subclasses during deprecation